### PR TITLE
Update jsDelivr link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Icon font for popular web frameworks and web related technologies
 #### Using a CDN
 To get started quickly, paste the following snippet within the head tag of your .html file
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/webdev-font/0.1.4/css/webdev-font.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/nickpolet/webdev-font@0.1.4/css/webdev-font.min.css">
 
 
 #### Using bower


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/gh/nickpolet/webdev-font.

Feel free to ping me if you have any questions regarding this change.